### PR TITLE
Support Service Injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
 
   include:
     # runs linting and tests with current locked deps

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Usage
 
 This addon does not provide any modifiers out of the box; instead (like Helpers), this library allows you to write your own.
 
+## Example without Cleanup
+
 For example, if you wanted to implement your own `scrollTop` modifier (similar to [this](https://github.com/emberjs/ember-render-modifiers#example-scrolling-an-element-to-a-position)), you may do something like this:
 
 ```js
@@ -51,6 +53,8 @@ Then, use it in your template:
   {{yield}}
 </div>
 ```
+
+## Example with Cleanup
 
 If the functionality you add in the modifier needs to be torn down when the element is removed, you can return a function for the teardown method.
 
@@ -79,6 +83,40 @@ export default makeFunctionalModifier(element => {
   {{yield}}
 </button>
 ```
+
+## Example with Service Injection
+
+You may also want to inject a service into your modifier.
+
+You can do that by supplying an injection object before the the modifier function. For example, suppose you wanted to track click events with `ember-metrics`:
+
+```js
+// app/modifiers/track-click.js
+import makeFunctionalModifier from 'ember-functional-modifiers';
+
+function trackClick(metrics, element, [eventName], options) {
+  const callback = () => metrics.trackEvent(eventName, options);
+
+  element.addEventListener('click', callback, true);
+
+  return () => element.removeEventListener('click', callback);
+}
+
+export default makeFunctionalModifier(
+  { services: ['metrics'] },
+  trackClick
+);
+```
+
+Then, you could use this in your template:
+
+```hbs
+<button {{track "Clicked the THING!"}}>
+  Click Me!
+</button>
+```
+
+*NOTE*: Because we are not observing the properties in the service in any way, if we are _reading_ a property on a service, the modifier will not recompute if that value changes. If that's the behavior you need, you probably want to pass that value into the modifier as an argument, rather than injecting it.
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/-private/functional-manager.js
+++ b/addon/-private/functional-manager.js
@@ -1,3 +1,5 @@
+import { getServiceInjections } from './service-injections';
+
 const MODIFIER_STATE = new WeakMap();
 
 function teardown(modifier) {
@@ -25,7 +27,9 @@ export default class FunctionalModifierManager {
   createModifier(factory) {
     // https://github.com/rwjblue/ember-modifier-manager-polyfill/issues/6
     const fn = factory.class ? factory.class : factory;
-    return (...args) => fn(...args);
+    const serivces = getServiceInjections(fn, factory.owner);
+
+    return (...args) => fn(...serivces, ...args);
   }
 
   installModifier(modifier, element, args) {

--- a/addon/-private/functional-manager.js
+++ b/addon/-private/functional-manager.js
@@ -24,9 +24,13 @@ function setup(modifier, element, args) {
 }
 
 export default class FunctionalModifierManager {
+  constructor(owner) {
+    this.owner = owner;
+  }
+
   createModifier(factory) {
-    const { class: fn, owner } = factory;
-    const services = getServiceInjections(fn, owner);
+    const { class: fn } = factory;
+    const services = getServiceInjections(fn, this.owner);
 
     return (...args) => fn(...services, ...args);
   }

--- a/addon/-private/functional-manager.js
+++ b/addon/-private/functional-manager.js
@@ -26,11 +26,23 @@ function setup(modifier, element, args) {
 export default class FunctionalModifierManager {
   constructor(owner) {
     this.owner = owner;
+    this.serviceCache = new WeakMap();
+  }
+
+  getServicesFor(fn) {
+    let services = this.serviceCache.get(fn);
+
+    if (services === undefined) {
+      services = getServiceInjections(fn, this.owner);
+      this.serviceCache.set(fn, services);
+    }
+
+    return services;
   }
 
   createModifier(factory) {
     const { class: fn } = factory;
-    const services = getServiceInjections(fn, this.owner);
+    const services = this.getServicesFor(fn);
 
     return (...args) => fn(...services, ...args);
   }

--- a/addon/-private/functional-manager.js
+++ b/addon/-private/functional-manager.js
@@ -25,11 +25,10 @@ function setup(modifier, element, args) {
 
 export default class FunctionalModifierManager {
   createModifier(factory) {
-    // https://github.com/rwjblue/ember-modifier-manager-polyfill/issues/6
-    const fn = factory.class ? factory.class : factory;
-    const serivces = getServiceInjections(fn, factory.owner);
+    const { class: fn, owner } = factory;
+    const services = getServiceInjections(fn, owner);
 
-    return (...args) => fn(...serivces, ...args);
+    return (...args) => fn(...services, ...args);
   }
 
   installModifier(modifier, element, args) {

--- a/addon/-private/service-injections.js
+++ b/addon/-private/service-injections.js
@@ -1,0 +1,15 @@
+const SERVICE_INjECTIONS = new WeakMap();
+
+export function setServiceInjections(fn, services = []) {
+  SERVICE_INjECTIONS.set(fn, services);
+}
+
+export function getServiceInjections(fn, owner) {
+  if (!SERVICE_INjECTIONS.has(fn)) {
+    return [];
+  }
+
+  const services = SERVICE_INjECTIONS.get(fn);
+
+  return services.map(service => owner.lookup(`service:${service}`));
+}

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,16 @@
 import Ember from 'ember';
 import FunctionalModifierManager from './-private/functional-manager';
+import { setServiceInjections } from './-private/service-injections';
 
 const SINGLETON_MANAGER = new FunctionalModifierManager();
 
-export default function makeFunctionalModifier(fn) {
+export default function makeFunctionalModifier(...args) {
+  const fn = args.pop();
+  const injections = args.shift();
+
+  if (injections && injections.services) {
+    setServiceInjections(fn, injections.services);
+  }
+
   return Ember._setModifierManager(() => SINGLETON_MANAGER, fn);
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,7 +2,16 @@ import Ember from 'ember';
 import FunctionalModifierManager from './-private/functional-manager';
 import { setServiceInjections } from './-private/service-injections';
 
-const SINGLETON_MANAGER = new FunctionalModifierManager();
+const MANAGERS = new WeakMap();
+
+function managerFor(owner) {
+  let manager = MANAGERS.get(owner);
+  if (manager === undefined) {
+    manager = new FunctionalModifierManager(owner);
+  }
+
+  return manager;
+}
 
 export default function makeFunctionalModifier(...args) {
   const fn = args.pop();
@@ -12,5 +21,5 @@ export default function makeFunctionalModifier(...args) {
     setServiceInjections(fn, injections.services);
   }
 
-  return Ember._setModifierManager(() => SINGLETON_MANAGER, fn);
+  return Ember._setModifierManager(managerFor, fn);
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -20,8 +20,7 @@ module.exports = function() {
           npm: {
             devDependencies: {
               '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-              'ember-modifier-manager-polyfill': '^1.0.2'
+              'ember-source': '~2.18.0'
             }
           }
         },
@@ -29,8 +28,7 @@ module.exports = function() {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {
-              'ember-source': '~3.4.0',
-              'ember-modifier-manager-polyfill': '^1.0.2'
+              'ember-source': '~3.4.0'
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ember-decorators/babel-transforms": "^3.1.5",
     "ember-cli-babel": "^7.1.2",
-    "ember-modifier-manager-polyfill": "^1.0.2"
+    "ember-modifier-manager-polyfill": "^1.0.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/tests/integration/modifier-managers/functional-modifiers-test.js
+++ b/tests/integration/modifier-managers/functional-modifiers-test.js
@@ -113,4 +113,27 @@ module('Integration | Modifier Manager | functional modifier', function(hooks) {
       assert.equal(callCount, 1);
     });
   });
+
+  module('service injection', () => {
+    test('it can inject a service', async function(assert) {
+      const service = {};
+
+      this.owner.register('service:foo', service, { instantiate: false });
+
+      this.registerModifier('songbird', makeFunctionalModifier(
+        {
+          services: ['foo']
+        },
+        hopefullyService => {
+          assert.equal(
+            service,
+            hopefullyService,
+            'the service is injected into the function'
+          );
+        }
+      );
+
+      await render(hbs`<h1 {{songbird}}>Hey</h1>`);
+    });
+  });
 });

--- a/tests/integration/modifier-managers/functional-modifiers-test.js
+++ b/tests/integration/modifier-managers/functional-modifiers-test.js
@@ -120,17 +120,20 @@ module('Integration | Modifier Manager | functional modifier', function(hooks) {
 
       this.owner.register('service:foo', service, { instantiate: false });
 
-      this.registerModifier('songbird', makeFunctionalModifier(
-        {
-          services: ['foo']
-        },
-        hopefullyService => {
-          assert.equal(
-            service,
-            hopefullyService,
-            'the service is injected into the function'
-          );
-        }
+      this.registerModifier(
+        'songbird',
+        makeFunctionalModifier(
+          {
+            services: ['foo']
+          },
+          hopefullyService => {
+            assert.equal(
+              service,
+              hopefullyService,
+              'the service is injected into the function'
+            );
+          }
+        )
       );
 
       await render(hbs`<h1 {{songbird}}>Hey</h1>`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5811,10 +5811,10 @@ ember-modal-dialog@3.0.0-beta.3:
     ember-ignore-children-helper "^1.0.1"
     ember-wormhole "^0.5.5"
 
-ember-modifier-manager-polyfill@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.2.tgz#c0b2da9816aad56fb1398023185c249cf76fe4bc"
-  integrity sha512-zu0gcSbQ7aOAtGFPQbMPQ1XKU2/NUBN6+Px65L9r4HxEzKXNUd76o1HE5p4QhLS1V6rNCD7UNmsi5r57ar0Rag==
+ember-modifier-manager-polyfill@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz#6554b70d09a7d3b80d366b72ed482fb9a3e813c0"
+  integrity sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==
   dependencies:
     ember-cli-babel "^7.4.2"
     ember-cli-version-checker "^2.1.2"


### PR DESCRIPTION
This PR adds support for injecting services into the arguments in a functional modifier. 

The use case for this may be for something along the lines of a dark-mode modifier (this example brought to you by [@pzuraq's blog post](https://www.pzuraq.com/coming-soon-in-ember-octane-part-4-modifiers/))

```js
// app/modifiers/dark-mode.js
import makeFunctionalModifier from 'ember-functional-modifiers';

function darkMode(userSettings, element, [darkModeClass]) {
  if (userSettings.darkModeEnabled) {
    element.classList.add(darkModeClass);

    return () => element.classList.remove(darkModeClass);
  }
}

export default makeFunctionalModifier(
  { services: ['userSettings'] },
  darkMode
);
```