### PR TITLE
add isRemoving flag to teardown method

### DIFF
--- a/addon/-private/functional-manager.js
+++ b/addon/-private/functional-manager.js
@@ -2,7 +2,7 @@ import { getServiceInjections } from './service-injections';
 
 const MODIFIER_STATE = new WeakMap();
 
-function teardown(modifier) {
+function teardown(modifier, isRemoving) {
   if (!MODIFIER_STATE.has(modifier)) {
     return;
   }
@@ -10,7 +10,7 @@ function teardown(modifier) {
   const { teardown, element } = MODIFIER_STATE.get(modifier);
 
   if (teardown && typeof teardown === 'function') {
-    teardown();
+    teardown(isRemoving);
   }
 
   return element;
@@ -52,11 +52,11 @@ export default class FunctionalModifierManager {
   }
 
   updateModifier(modifier, args) {
-    const element = teardown(modifier);
+    const element = teardown(modifier, false);
     setup(modifier, element, args);
   }
 
   destroyModifier(modifier) {
-    teardown(modifier);
+    teardown(modifier, true);
   }
 }

--- a/tests/integration/modifier-managers/functional-modifiers-test.js
+++ b/tests/integration/modifier-managers/functional-modifiers-test.js
@@ -112,6 +112,34 @@ module('Integration | Modifier Manager | functional modifier', function(hooks) {
 
       assert.equal(callCount, 1);
     });
+
+    test('teardown is invoked with `isRemoving` flag', async function(assert) {
+      this.value = 0;
+      this.shouldRender = true;
+
+      this.registerModifier(
+        'songbird',
+        makeFunctionalModifier(() => isRemoving =>
+          assert.step(isRemoving ? 'removing' : 'updating')
+        )
+      );
+
+      await render(hbs`
+        {{#if this.shouldRender}}
+          <h1 {{songbird value}}>Hello</h1>
+        {{/if}}
+      `);
+
+      this.set('value', 1);
+
+      await settled();
+
+      this.set('shouldRender', false);
+
+      await settled();
+
+      assert.verifySteps(['updating', 'removing']);
+    });
   });
 
   module('service injection', () => {


### PR DESCRIPTION
This adds a `isRemoving` boolean to the teardown method so the teardown method can distinguish between an update teardown and a `willRemove` teardown.

Resolves: https://github.com/spencer516/ember-functional-modifiers/issues/8 