### PR TITLE
Use yarn in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ dist: trusty
 addons:
   chrome: stable
 
-cache:
-  directories:
-    - $HOME/.npm
+cache: yarn
 
 env:
   global:
@@ -37,9 +35,9 @@ jobs:
     - stage: 'Tests'
       name: 'Tests'
       script:
-        - npm run lint:hbs
-        - npm run lint:js
-        - npm test
+        - yarn run lint:hbs
+        - yarn run lint:js
+        - yarn test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
@@ -51,10 +49,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
-before_install:
-  - npm config set spin false
-  - npm install -g npm@4
-  - npm --version
+install:
+  - yarn install
 
 script:
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+  - yarn try $EMBER_TRY_SCENARIO --skip-cleanup

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,6 +9,7 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then(urls => {
     return {
+      useYarn: true,
       scenarios: [
         {
           name: 'ember-lts-2.18',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
-    "release": "release-it"
+    "release": "release-it",
+    "try": "ember try:one"
   },
   "dependencies": {
     "@ember-decorators/babel-transforms": "^3.1.5",


### PR DESCRIPTION
This repository has a `yarn.lock` so I suppose Travis should use `yarn`, too. 